### PR TITLE
 Dedupe eror messages to see where something went wrong

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Output
-build/
+build/**
+!build/.keep
 Makefile.deps
 html
 latex

--- a/src/pdf-sigil.c
+++ b/src/pdf-sigil.c
@@ -169,10 +169,10 @@ int main(int argc, char *argv[])
         if (!quiet) {
             if (err == ERR_NOT_IMPLEMENTED) {
                 fprintf(stderr, COLOR_RED
-                        " ERROR file uses feature that is not implemented\n"COLOR_RESET);
+                        " ERROR Unable to verify file: Uses feature that is not implemented\n"COLOR_RESET);
             } else {
                 fprintf(stderr, COLOR_RED
-                        " ERROR obtaining verification result from the context\n"COLOR_RESET);
+                        " ERROR Unable to object verification result for file from the context\n"COLOR_RESET);
             }
         }
         goto end;


### PR DESCRIPTION
Includes a commit that creates a build dir with .keep and excludes everything in that dir